### PR TITLE
Fix progress bar for single file

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function mvFile(currentDir, originalFilePath, newFilePath, options, cb) {
     steps = [function(cb) {
       rename(originalFilePath, newFilePath, options.git, cb)
     }];
-    bar = new ProgressBar(':bar', {total: files.length});
+    bar = new ProgressBar(':bar', {total: 1});
     excludes = getExcludes(options);
     steps.push(function(cb) {updateReferencesInMovedFile(originalFilePath, newFilePath, null, cb)});
     steps.push(function(cb) {updateReferencesToMovedFile(currentDir, originalFilePath, newFilePath, excludes, cb)});


### PR DESCRIPTION
When moving a single file, the program crashes:

```
/Users/geowarin/dev/2015/phaser-webpack/node_modules/node-mv/index.js:32
  bar = new ProgressBar(':bar', {total: files.length});
                                        ^
ReferenceError: files is not defined
```

Which is not surprising. Is progress bar really needed for single files?
If not consider removing it from the code. Otherwise see the change in the PR.

Thanks!